### PR TITLE
Fix vflow to use Source ID (or Observation Domain ID) from NetFlow9 (or IPFIX) messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,17 @@ LDFLAGS= -ldflags "-X main.version=${VERSION}"
 DEBPATH= scripts/dpkg
 RPMPATH= scripts/rpmbuild
 ARCH=`uname -m`
+BUILD_OS := $(shell uname -s)
 
 default: test
 
 test:
-	go test -count=1 -v ./... -timeout 1m
+ifeq ($(BUILD_OS),Darwin)
+	go test -count=1 -v `go list ./... | grep -v "vflow/vflow" | grep -v "mirror"` -timeout 1m
+endif
+ifeq ($(BUILD_OS),Linux)
+	go test -count=1 -v `go list ./... | grep -v "mirror"` -timeout 1m
+endif
 
 bench:
 	go test -v ./... -bench=. -timeout 2m

--- a/ipfix/decoder_test.go
+++ b/ipfix/decoder_test.go
@@ -205,8 +205,8 @@ func TestUnknownDatasetsMessage(t *testing.T) {
 		t.Error("Did not expect any result datasets, but got", l)
 	}
 	expectedErrorStr := `Multiple errors:
-- 127.0.0.1 unknown ipfix template id# 264
-- 127.0.0.1 unknown ipfix template id# 264`
+- 127.0.0.1 unknown ipfix template id# 264 source ID 1
+- 127.0.0.1 unknown ipfix template id# 264 source ID 1`
 	if err == nil || err.Error() != expectedErrorStr {
 		t.Error("Received unexpected erorr:", err)
 	}

--- a/ipfix/decoder_test.go
+++ b/ipfix/decoder_test.go
@@ -205,8 +205,8 @@ func TestUnknownDatasetsMessage(t *testing.T) {
 		t.Error("Did not expect any result datasets, but got", l)
 	}
 	expectedErrorStr := `Multiple errors:
-- 127.0.0.1 unknown ipfix template id# 264 source ID 1
-- 127.0.0.1 unknown ipfix template id# 264 source ID 1`
+- 127.0.0.1 unknown ipfix template id# 264 for source ID 1
+- 127.0.0.1 unknown ipfix template id# 264 for source ID 1`
 	if err == nil || err.Error() != expectedErrorStr {
 		t.Error("Received unexpected erorr:", err)
 	}

--- a/ipfix/memcache.go
+++ b/ipfix/memcache.go
@@ -79,27 +79,32 @@ func GetCache(cacheFile string) MemCache {
 	return m
 }
 
-func (m MemCache) getShard(id uint16, addr net.IP) (*TemplatesShard, uint32) {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, id)
-	key := append(addr, b...)
+func (m MemCache) getShard(id uint16, addr net.IP, srcId uint32) (*TemplatesShard, uint32) {
+	bSrcId := make([]byte, 4)
+	btemplateId := make([]byte, 2)
+	binary.BigEndian.PutUint32(bSrcId, srcId)
+	binary.BigEndian.PutUint16(btemplateId, id)
+
+	var key []byte
+	key = append(key, addr...)
+	key = append(key, bSrcId...)
+	key = append(key, btemplateId...)
 
 	hash := fnv.New32()
 	hash.Write(key)
 	hSum32 := hash.Sum32()
-
 	return m[uint(hSum32)%uint(shardNo)], hSum32
 }
 
-func (m MemCache) insert(id uint16, addr net.IP, tr TemplateRecord) {
-	shard, key := m.getShard(id, addr)
+func (m MemCache) insert(id uint16, addr net.IP, tr TemplateRecord, srcId uint32) {
+	shard, key := m.getShard(id, addr, srcId)
 	shard.Lock()
 	defer shard.Unlock()
 	shard.Templates[key] = Data{tr, time.Now().Unix()}
 }
 
-func (m MemCache) retrieve(id uint16, addr net.IP) (TemplateRecord, bool) {
-	shard, key := m.getShard(id, addr)
+func (m MemCache) retrieve(id uint16, addr net.IP, srcId uint32) (TemplateRecord, bool) {
+	shard, key := m.getShard(id, addr, srcId)
 	shard.RLock()
 	defer shard.RUnlock()
 	v, ok := shard.Templates[key]

--- a/ipfix/memcache.go
+++ b/ipfix/memcache.go
@@ -79,16 +79,16 @@ func GetCache(cacheFile string) MemCache {
 	return m
 }
 
-func (m MemCache) getShard(id uint16, addr net.IP, srcId uint32) (*TemplatesShard, uint32) {
-	bSrcId := make([]byte, 4)
-	btemplateId := make([]byte, 2)
-	binary.BigEndian.PutUint32(bSrcId, srcId)
-	binary.BigEndian.PutUint16(btemplateId, id)
+func (m MemCache) getShard(id uint16, addr net.IP, srcID uint32) (*TemplatesShard, uint32) {
+	bSrcID := make([]byte, 4)
+	btemplateID := make([]byte, 2)
+	binary.BigEndian.PutUint32(bSrcID, srcID)
+	binary.BigEndian.PutUint16(btemplateID, id)
 
 	var key []byte
 	key = append(key, addr...)
-	key = append(key, bSrcId...)
-	key = append(key, btemplateId...)
+	key = append(key, bSrcID...)
+	key = append(key, btemplateID...)
 
 	hash := fnv.New32()
 	hash.Write(key)
@@ -96,15 +96,15 @@ func (m MemCache) getShard(id uint16, addr net.IP, srcId uint32) (*TemplatesShar
 	return m[uint(hSum32)%uint(shardNo)], hSum32
 }
 
-func (m MemCache) insert(id uint16, addr net.IP, tr TemplateRecord, srcId uint32) {
-	shard, key := m.getShard(id, addr, srcId)
+func (m MemCache) insert(id uint16, addr net.IP, tr TemplateRecord, srcID uint32) {
+	shard, key := m.getShard(id, addr, srcID)
 	shard.Lock()
 	defer shard.Unlock()
 	shard.Templates[key] = Data{tr, time.Now().Unix()}
 }
 
-func (m MemCache) retrieve(id uint16, addr net.IP, srcId uint32) (TemplateRecord, bool) {
-	shard, key := m.getShard(id, addr, srcId)
+func (m MemCache) retrieve(id uint16, addr net.IP, srcID uint32) (TemplateRecord, bool) {
+	shard, key := m.getShard(id, addr, srcID)
 	shard.RLock()
 	defer shard.RUnlock()
 	v, ok := shard.Templates[key]

--- a/ipfix/memcache_rpc.go
+++ b/ipfix/memcache_rpc.go
@@ -58,6 +58,7 @@ type RPCConfig struct {
 type RPCRequest struct {
 	ID uint16
 	IP net.IP
+	SrcID uint32
 }
 
 type vFlowServer struct {
@@ -91,7 +92,7 @@ func NewRPC(mCache MemCache) *IRPC {
 func (r *IRPC) Get(req RPCRequest, resp *TemplateRecord) error {
 	var ok bool
 
-	*resp, ok = r.mCache.retrieve(req.ID, req.IP)
+	*resp, ok = r.mCache.retrieve(req.ID, req.IP, req.SrcID)
 	if !ok {
 		return errNotAvail
 	}
@@ -168,7 +169,7 @@ func RPC(m MemCache, config *RPCConfig) {
 				continue
 			}
 
-			m.insert(req.ID, req.IP, *tr)
+			m.insert(req.ID, req.IP, *tr, req.SrcID)
 			break
 		}
 

--- a/ipfix/memcache_test.go
+++ b/ipfix/memcache_test.go
@@ -33,7 +33,7 @@ func TestMemCacheRetrieve(t *testing.T) {
 	mCache := GetCache("cache.file")
 	d := NewDecoder(ip, tpl)
 	d.Decode(mCache)
-	v, ok := mCache.retrieve(256, ip)
+	v, ok := mCache.retrieve(256, ip, 33792)
 	if !ok {
 		t.Error("expected mCache retrieve status true, got", ok)
 	}
@@ -48,9 +48,9 @@ func TestMemCacheInsert(t *testing.T) {
 	mCache := GetCache("cache.file")
 
 	tpl.TemplateID = 310
-	mCache.insert(310, ip, tpl)
+	mCache.insert(310, ip, tpl, 512)
 
-	v, ok := mCache.retrieve(310, ip)
+	v, ok := mCache.retrieve(310, ip, 512)
 	if !ok {
 		t.Error("expected mCache retrieve status true, got", ok)
 	}
@@ -65,11 +65,11 @@ func TestMemCacheAllSetIds(t *testing.T) {
 	mCache := GetCache("cache.file")
 
 	tpl.TemplateID = 310
-	mCache.insert(tpl.TemplateID, ip, tpl)
+	mCache.insert(tpl.TemplateID, ip, tpl,  512)
 	tpl.TemplateID = 410
-	mCache.insert(tpl.TemplateID, ip, tpl)
+	mCache.insert(tpl.TemplateID, ip, tpl, 512)
 	tpl.TemplateID = 210
-	mCache.insert(tpl.TemplateID, ip, tpl)
+	mCache.insert(tpl.TemplateID, ip, tpl, 512)
 
 	expected := []int{210, 310, 410}
 	actual := mCache.allSetIds()

--- a/netflow/v9/decoder.go
+++ b/netflow/v9/decoder.go
@@ -430,11 +430,12 @@ func (d *Decoder) decodeSet(mem MemCache, msg *Message) error {
 	// This check is somewhat redundant with the switch-clause below, but the retrieve() operation should not be executed inside the loop.
 	if setHeader.FlowSetID > 255 {
 		var ok bool
-		tr, ok = mem.retrieve(setHeader.FlowSetID, d.raddr)
+		tr, ok = mem.retrieve(setHeader.FlowSetID, d.raddr, msg.Header.SrcID)
 		if !ok {
-			err = nonfatalError(fmt.Errorf("%s unknown netflow template id# %d",
+			err = nonfatalError(fmt.Errorf("%s unknown netflow template id# %d from source ID: %d",
 				d.raddr.String(),
 				setHeader.FlowSetID,
+				msg.Header.SrcID,
 			))
 		}
 	}
@@ -450,7 +451,7 @@ func (d *Decoder) decodeSet(mem MemCache, msg *Message) error {
 				err = tr.unmarshalOpts(d.reader)
 			}
 			if err == nil {
-				mem.insert(tr.TemplateID, d.raddr, tr)
+				mem.insert(tr.TemplateID, d.raddr, tr, msg.Header.SrcID)
 			}
 		} else if setId >= 4 && setId <= 255 {
 			// Reserved set, do not read any records

--- a/netflow/v9/memcache.go
+++ b/netflow/v9/memcache.go
@@ -79,27 +79,32 @@ func GetCache(cacheFile string) MemCache {
 	return m
 }
 
-func (m MemCache) getShard(id uint16, addr net.IP) (*TemplatesShard, uint32) {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, id)
-	key := append(addr, b...)
+func (m MemCache) getShard(id uint16, addr net.IP, srcId uint32) (*TemplatesShard, uint32) {
+	bSrcId := make([]byte, 4)
+	btemplateId := make([]byte, 2)
+	binary.BigEndian.PutUint32(bSrcId, srcId)
+	binary.BigEndian.PutUint16(btemplateId, id)
+
+	var key []byte
+	key = append(key, addr...)
+	key = append(key, bSrcId...)
+	key = append(key, btemplateId...)
 
 	hash := fnv.New32()
 	hash.Write(key)
 	hSum32 := hash.Sum32()
-
 	return m[uint(hSum32)%uint(shardNo)], hSum32
 }
 
-func (m *MemCache) insert(id uint16, addr net.IP, tr TemplateRecord) {
-	shard, key := m.getShard(id, addr)
+func (m *MemCache) insert(id uint16, addr net.IP, tr TemplateRecord, srcId uint32) {
+	shard, key := m.getShard(id, addr, srcId uint32)
 	shard.Lock()
 	defer shard.Unlock()
 	shard.Templates[key] = Data{tr, time.Now().Unix()}
 }
 
-func (m *MemCache) retrieve(id uint16, addr net.IP) (TemplateRecord, bool) {
-	shard, key := m.getShard(id, addr)
+func (m *MemCache) retrieve(id uint16, addr net.IP, srcId uint32) (TemplateRecord, bool) {
+	shard, key := m.getShard(id, addr, srcId)
 	shard.RLock()
 	defer shard.RUnlock()
 	v, ok := shard.Templates[key]

--- a/netflow/v9/memcache.go
+++ b/netflow/v9/memcache.go
@@ -79,16 +79,16 @@ func GetCache(cacheFile string) MemCache {
 	return m
 }
 
-func (m MemCache) getShard(id uint16, addr net.IP, srcId uint32) (*TemplatesShard, uint32) {
-	bSrcId := make([]byte, 4)
-	btemplateId := make([]byte, 2)
-	binary.BigEndian.PutUint32(bSrcId, srcId)
-	binary.BigEndian.PutUint16(btemplateId, id)
+func (m MemCache) getShard(id uint16, addr net.IP, srcID uint32) (*TemplatesShard, uint32) {
+	bSrcID := make([]byte, 4)
+	btemplateID := make([]byte, 2)
+	binary.BigEndian.PutUint32(bSrcID, srcID)
+	binary.BigEndian.PutUint16(btemplateID, id)
 
 	var key []byte
 	key = append(key, addr...)
-	key = append(key, bSrcId...)
-	key = append(key, btemplateId...)
+	key = append(key, bSrcID...)
+	key = append(key, btemplateID...)
 
 	hash := fnv.New32()
 	hash.Write(key)
@@ -96,15 +96,15 @@ func (m MemCache) getShard(id uint16, addr net.IP, srcId uint32) (*TemplatesShar
 	return m[uint(hSum32)%uint(shardNo)], hSum32
 }
 
-func (m *MemCache) insert(id uint16, addr net.IP, tr TemplateRecord, srcId uint32) {
-	shard, key := m.getShard(id, addr, srcId uint32)
+func (m *MemCache) insert(id uint16, addr net.IP, tr TemplateRecord, srcID uint32) {
+	shard, key := m.getShard(id, addr, srcID)
 	shard.Lock()
 	defer shard.Unlock()
 	shard.Templates[key] = Data{tr, time.Now().Unix()}
 }
 
-func (m *MemCache) retrieve(id uint16, addr net.IP, srcId uint32) (TemplateRecord, bool) {
-	shard, key := m.getShard(id, addr, srcId)
+func (m *MemCache) retrieve(id uint16, addr net.IP, srcID uint32) (TemplateRecord, bool) {
+	shard, key := m.getShard(id, addr, srcID)
 	shard.RLock()
 	defer shard.RUnlock()
 	v, ok := shard.Templates[key]


### PR DESCRIPTION
Fix vflow to use Source ID (or Observation Domain ID) from NetFlow9 (or IPFIX) messages